### PR TITLE
Avoid Race Conditions around Saving Input and Output Files

### DIFF
--- a/pymw/pymw.py
+++ b/pymw/pymw.py
@@ -687,8 +687,11 @@ class PyMW_Master:
 		return obj
 	
 	def pymw_master_write(self, output, loc):
+		import os
 		outfile = open(loc, 'wb')
 		pickle.Pickler(outfile).dump(output)
+		outfile.flush()
+		os.fsync(outfile.fileno())
 		outfile.close()
 	
 	def pymw_worker_read(options):
@@ -698,8 +701,11 @@ class PyMW_Master:
 		return obj
 
 	def pymw_worker_write(output, options):
+		import os
 		outfile = open(sys.argv[2], 'wb')
 		pickle.Pickler(outfile).dump(output)
+		outfile.flush()
+		os.fsync(outfile.fileno())
 		outfile.close()
 
 	def pymw_set_progress(prog_ratio):


### PR DESCRIPTION
It is guaranteed that a call to the close() method of a file object will
eventually flush the write buffer to the disk, but it is not guaranteed
that this will happen before the method returns. In particular, if a
task finishes too quickly, the worker will close the output file, report
the task as finished, the manager will try to read a file that is not
guaranteed to exist.

According to http://docs.python.org/2/library/os.html#os.fsync the
correct way to guarantee the existence of a file is doing flush() ->
os.sync() -> close() as implemented in this patch.
