### PR TITLE
Avoid Name Collisions in Temporal Script Files

### DIFF
--- a/pymw/pymw.py
+++ b/pymw/pymw.py
@@ -541,8 +541,14 @@ class PyMW_Master:
 		
 		# Check if the executable is a Python function or a script
 		if hasattr(executable, '__call__'):
-			task_name = str(executable.__name__)+"_"+self._start_time_str+"_"+str(self._cur_task_num)
-			exec_file_name = self._task_dir_name+"/"+str(executable.__name__)+"_"+self._start_time_str+".py"
+			# Name depends on whether it is a method or just a function
+			if hasattr(executable, 'im_class'):
+				exec_name = executable.im_class.__module__+"."+executable.im_class.__name__+"."+executable.__name__
+			else:
+				exec_name = executable.__module__+"."+executable.__name__
+			task_prefix = exec_name+"_"+self._start_time_str
+			task_name = task_prefix+"_"+str(self._cur_task_num)
+			exec_file_name = self._task_dir_name+"/"+task_prefix+".py"
 		elif isinstance(executable, str):
 			# TODO: test here for existence of script
 			task_name = str(executable)+"_"+self._start_time_str+"_"+str(self._cur_task_num)


### PR DESCRIPTION
The original code is suitable for SIMD configurations where a single
method is executed several times. This change allows for PyMW to be used
in MIMD or MISD configurations, where the name of the methods that are
being executed can actually collision.

One case where this could happen easily is in class methods, so the code
deals with naming these separately. This code is inspired in
observations made at http://bugs.python.org/issue9276 about bound and
unbound method naming.

There are cases that are probably not covered, like nested methods or
methods of nested classes, but these changes should cover most of the
common cases.
