### PR TITLE
Updated boinc.py interface to fix missing xml-tag

### DIFF
--- a/pymw/interfaces/boinc.py
+++ b/pymw/interfaces/boinc.py
@@ -34,12 +34,12 @@ INPUT_TEMPLATE = """\
 $INPUT_ZIP_INFO
 <workunit>
 	<file_ref>
-		<file_number>0<file_number>
+		<file_number>0</file_number>
 		<open_name>$PYMW_EXECUTABLE</open_name>
 		<copy_file/>
 	</file_ref>
 	<file_ref>
-		<file_number>1<file_number>
+		<file_number>1</file_number>
 		<open_name>$PYMW_INPUT</open_name>
 		<copy_file/>
 	</file_ref>


### PR DESCRIPTION
Changed a tag that did not have an ending in boinc interface in-template.
